### PR TITLE
fix for null pointer exception edge case

### DIFF
--- a/src/main/java/SolrLogReader.java
+++ b/src/main/java/SolrLogReader.java
@@ -303,13 +303,15 @@ public class SolrLogReader {
   private static void getFiles(List<File> files, File file, String matchText) {
     if (file.isDirectory()) {
       File[] listFiles = file.listFiles();
-      for (File f : listFiles) {
-        if (f.isFile()) {
-          if (matchText == null || f.getName().matches(matchText)) {
-            files.add(f);
+      if(listFiles != null) {
+        for (File f : listFiles) {
+          if (f.isFile()) {
+            if (matchText == null || f.getName().matches(matchText)) {
+              files.add(f);
+            }
+          } else {
+            getFiles(files, f, matchText);
           }
-        } else {
-          getFiles(files, f, matchText);
         }
       }
     } else {


### PR DESCRIPTION
Fix for null pointer error when built & run on CentOS7/JDK8

Exception in thread "main" java.lang.NullPointerException
        at SolrLogReader.getFiles(SolrLogReader.java:306)
        at SolrLogReader.getFiles(SolrLogReader.java:312)
        at SolrLogReader.summarize(SolrLogReader.java:189)
        at SolrLogReader.main(SolrLogReader.java:73)

